### PR TITLE
fix: TypeError: lastPrepareStackTrace is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,5 +40,5 @@ function prepareStackTrace (err, callsites) {
     value: callsites
   })
 
-  return lastPrepareStackTrace(err, callsites)
+  return lastPrepareStackTrace && lastPrepareStackTrace(err, callsites)
 }


### PR DESCRIPTION
https://github.com/watson/error-callsites/issues/3