### PR TITLE
fix: support a user setting Error.prepareStackTrace=undefined to get the JS engine default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix a crash when a user set `Error.prepareStackTrace = undefined`, which
+  is a way of saying "give me the JS engine's default stack formatting".
+  ([#3](https://github.com/watson/error-callsites/issues/3))
 - Internal maintenance changes:
     - @trentm is mostly maintaining this module now
     - Switch from TravisCI to GitHub CI. Add testing for node v14 and v16.


### PR DESCRIPTION
Fixes: #3
